### PR TITLE
Added platform to the list of games in manual mode.

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -126,6 +126,13 @@ def getTitle(nodes):
     else:
         return getText(nodes.find("GameTitle"))
 
+def getGamePlatform(nodes):
+    if args.crc:
+        return getText(nodes.find("system_title"))
+    else:
+        return getText(nodes.find("Platform"))
+    
+    
 def getDescription(nodes):
     if args.crc:
         return getText(nodes.find("description"))
@@ -194,7 +201,7 @@ def chooseResult(nodes):
     results=nodes.findall('Game')
     if len(results) > 1:
         for i,v in enumerate(results):
-            print "[{}] {}".format(i,getTitle(v))
+            print "[{}] {} | {}".format(i,getTitle(v), getGamePlatform(v))
         return int(raw_input("Select a result (or press Enter to skip): "))
     else:
         return 0


### PR DESCRIPTION
When scraping in manual mode, the thegamesdb.net API often returns games of the wrong platform. For example, querying the GBA game "Advance Wars 2 - Black Hole Rising" also returns matches to "Dead Rising 2" for the PS3. Other times, the game exists with the exact same name in other platforms, and the user has to choosing blindly 2 or 3 versions.

This patch adds the platform name to the list for manual selection, example:

Trying to identify Advance Wars.gba..
[0] Advance Wars | Nintendo Game Boy Advance
[1] Advance Wars: Days of Ruin | Nintendo DS
[2] Contra Advance: The Alien Wars EX | Nintendo Game Boy Advance
[3] Advance Wars: Dual Strike | Nintendo DS
